### PR TITLE
feat: add conventional commits to recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,7 +15,8 @@
 		"ms-python.vscode-pylance",
 		"njpwerner.autodocstring",
 		"quarto.quarto",
-		"streetsidesoftware.code-spell-checker"
+		"streetsidesoftware.code-spell-checker",
+		"vivaxy.vscode-conventional-commits"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [


### PR DESCRIPTION
I have been using this extension for the last couple of days, and it's quite nice, when you're just getting started with conventional commits. When you want to commit, you just open the command palette and write "conventional commits". 

Then the extension takes you through the whole process with prefix, scope, message, additional info, and breaking changes.