### PR TITLE
Remove code of conduct in sidebar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -39,6 +39,8 @@ website:
               href: community/CONTRIBUTING.md
             - auto: community/guide-entries
             - auto: community/decisions
+            - text: "Code of Conduct"
+              href: "https://github.com/seedcase-project/.github/blob/main/CODE_OF_CONDUCT.md"
         - community/blocks.qmd
         - community/roadmap.qmd
     - id: design

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -39,7 +39,6 @@ website:
               href: community/CONTRIBUTING.md
             - auto: community/guide-entries
             - auto: community/decisions
-            - community/CODE_OF_CONDUCT.md
         - community/blocks.qmd
         - community/roadmap.qmd
     - id: design


### PR DESCRIPTION
Since we have moved Code of Conduct to the .github repo, it should be removed from the _quarto.yml file as well. Otherwise, it is shown as an unclickable text in the sidebar.