### PR TITLE
fix: :pencil2: change landing page theme from scss to css

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -3,7 +3,7 @@ title: "Welcome to the Seedcase Project"
 subtitle: A framework for an open and scalable infrastructure for health data
 toc: false
 sidebar: false
-css: _extensions/seedcase-project/seedcase-theme/landing-page-theme.scss
+css: _extensions/seedcase-project/seedcase-theme/landing-page-theme.css
 about:
   id: hero-heading
   template: marquee


### PR DESCRIPTION
## Description

See seedcase-project/seedcase-theme#59.
(I changed the file extension of landing-page-theme from scss to css, so naturally, I need to change it here too).

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.

Focus on CHANGES.