### PR TITLE
fix: remove propagate and garden from landing page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -30,23 +30,22 @@ open-source software. We believe that by developing open-source software
 and providing researchers with training in technical skills, we can
 enhance health and well-being research.
 
-See our [Roadmap](/roadmap/index.qmd) or our
-[About](about/index.qmd) page for more information about the project,
-our values, and our goals.
+See our [Roadmap](/roadmap/index.qmd) or our [About](about/index.qmd)
+page for more information about the project, our values, and our goals.
 :::
 ::::
 :::::
 
-:::::::: landing-page-block
+:::::: landing-page-block
 ## Software products
 
 **Seedcase** will take you from structuring and documenting your data,
 and being able to browse and share your metadata.
 
-We plan to create multiple software products that run both separately and
-together:
+We plan to create multiple software products that run both separately
+and together:
 
-::::::: grid
+::::: grid
 ::: {.g-col-6 .text-center}
 ![](_extensions/seedcase-project/seedcase-theme/logos/sprout-logo.svg){fig-alt="Sprout logo"
 position="center" width="150px"}
@@ -65,13 +64,12 @@ position="center" width="150px"}
 
 Submit requests for accessing specific data from a data package
 :::
+:::::
+::::::
 
-:::::::
-::::::::
-
-::::::::: hero-banner
-:::::::: landing-page-block
-::::::: hero-text
+::::: hero-banner
+:::: landing-page-block
+::: hero-text
 ## Goals
 
 The Seedcase Project is more than software: It is also about education,
@@ -97,9 +95,9 @@ engineering.
 
 By building this project as fully open as possible and applying the same
 principles we teach and advocate for.
-:::::::
-::::::::
-:::::::::
+:::
+::::
+:::::
 
 :::::: landing-page-block
 ## Acknowledgements {#acknowledgements}

--- a/index.qmd
+++ b/index.qmd
@@ -41,49 +41,31 @@ our values, and our goals.
 ## Software products
 
 **Seedcase** will take you from structuring and documenting your data,
-being able to browse and share it, to tending to projects using the
-data.
+and being able to browse and share your metadata.
 
-We plan to create four software products that run both separately and
+We plan to create multiple software products that run both separately and
 together:
 
 ::::::: grid
-::: {.g-col-3 .text-center}
+::: {.g-col-6 .text-center}
 ![](_extensions/seedcase-project/seedcase-theme/logos/sprout-logo.svg){fig-alt="Sprout logo"
-position="center" width="80%"}
+position="center" width="150px"}
 
 ### [Sprout](https://sprout.seedcase-project.org/)
 
-Grow your data in a structured and healthy way
-:::
-
-::: {.g-col-3 .text-center}
-![](_extensions/seedcase-project/seedcase-theme/logos/flower-logo.svg){fig-alt="Flower logo"
-position="center" width="80%"}
-
-### Flower
-
-Submit requests for accessing specific data from a [data
+Grow your data in a structured and healthy way in a [data
 package](https://decisions.seedcase-project.org/why-frictionless-data/)
 :::
 
-::: {.g-col-3 .text-center}
-![](_extensions/seedcase-project/seedcase-theme/logos/propagate-logo.svg){fig-alt="Propagate logo"
-position="center" width="80%"}
+::: {.g-col-6 .text-center}
+![](_extensions/seedcase-project/seedcase-theme/logos/flower-logo.svg){fig-alt="Flower logo"
+position="center" width="150px"}
 
-### Propagate
+### Flower
 
 Submit requests for accessing specific data from a data package
 :::
 
-::: {.g-col-3 .text-center}
-![](_extensions/seedcase-project/seedcase-theme/logos/garden-logo.svg){fig-alt="Garden logo"
-position="center" width="80%"}
-
-### Garden
-
-Tend to multiple projects using data from a data package
-:::
 :::::::
 ::::::::
 


### PR DESCRIPTION
# Description

This PR removes Propagate and Garden from the landing page because they are not in the roadmap anymore. 

This PR needs a quick review.

## Checklist

- [X] Formatted Markdown
- [X] Ran `just run-all`
