### PR TITLE
refactor: 🔥 remove software and software-related from how to guides and reference

### DIFF
--- a/roadmap/index.qmd
+++ b/roadmap/index.qmd
@@ -50,10 +50,10 @@ work within software environments, integrate with other workflows, or
 support research software and data engineering.
 
 ::: callout-note
-Since we aim to build beginner-friendly tools, we put a strong emphasis
-on documentation.
-Our software and software-related products include technical documentation in the form of design documentation, usage guides, and reference documentation when
-relevant.
+To make our tools easier to get started with for novices and experts alike,
+we put a strong emphasis on documentation.
+Our software and software-related products generally include documentation
+on design decisions, usage patterns, and an API reference.
 :::
 
 ::: panel-tabset

--- a/roadmap/index.qmd
+++ b/roadmap/index.qmd
@@ -166,8 +166,6 @@ packages).
 
 | Status | Information resource |
 |:--------------------------------------------:|:-------------------------|
-| {{< var status.done >}} | [`seedcase-sprout`](https://sprout.seedcase-project.org/docs/reference/): Reference docs for Sprout |
-| {{< var status.done >}} | [`check-datapackage`](https://check-datapackage.seedcase-project.org/docs/reference/): Reference docs for `check-datapackage` |
 | {{< var status.ongoing >}} | [`design`](https://github.com/seedcase-project/design): Principles and patterns for development in the Seedcase Project |
 | {{< var status.ongoing >}} | [`team`](https://github.com/seedcase-project/team): Internal docs for onboarding and admin information |
 | {{< var status.ongoing >}} | [`seedcase-website`](https://github.com/seedcase-project/seedcase-website): Main website for the Seedcase Project |

--- a/roadmap/index.qmd
+++ b/roadmap/index.qmd
@@ -43,10 +43,9 @@ Because software development is an ongoing process, software products
 are rarely truly "complete". They continue to evolve through updates and
 improvements. A product is considered to have reached MVP and "done"
 status once its first version is released on an official software
-archive (like PyPI for Python packages). If the product gets sufficient
-use, it will continue to be tested and refined based on user feedback.
+archive (like PyPI for Python packages).
 
-Some of these products are not strictly software, but are designed to
+Some of these products are not strictly software (e.g., templates), but are designed to
 work within software environments, integrate with other workflows, or
 support research software and data engineering.
 

--- a/roadmap/index.qmd
+++ b/roadmap/index.qmd
@@ -126,16 +126,7 @@ user manuals.
 
 | Status | Guides or manuals |
 |:--------------------------------------------:|:-------------------------|
-| {{< var status.done >}} | [`seedcase-sprout`](https://sprout.seedcase-project.org/docs/guide) usage guide: Using and interacting with `seedcase-sprout` |
-| {{< var status.done >}} | [`check-datapackage`](https://check-datapackage.seedcase-project.org/docs/guide) usage guide: Using and interacting with `seedcase-check-datapackage` |
-| {{< var status.done >}} | [`template-data-package`](https://template-data-package.seedcase-project.org/docs/guide) usage guide: Using the template to make data packages |
-| {{< var status.done >}} | [`template-website`](https://template-website.seedcase-project.org/docs/guide) usage guide: Using the template to make websites |
-| {{< var status.done >}} | [`template-python-package`](https://template-python-package.seedcase-project.org/docs/guide) usage guide: Using the template to make Python packages |
 | {{< var status.wip >}} | [`guidebook`](https://guidebook.seedcase-project.org/): A guidebook for team collaboration on GitHub |
-| {{< var status.planned >}} | Flower usage guide: Using and interacting with `seedcase-flower` |
-| {{< var status.planned >}} | Propagate usage guide: Using and interacting with `seedcase-propagate` |
-| {{< var status.planned >}} | Garden usage guide: Using and interacting with `seedcase-garden` |
-| {{< var status.planned >}} | Shears usage guide: Using and interacting with `seedcase-shears` |
 
 : "Wishlist" of goal-type documentation products.
 

--- a/roadmap/index.qmd
+++ b/roadmap/index.qmd
@@ -50,6 +50,13 @@ Some of these products are not strictly software, but are designed to
 work within software environments, integrate with other workflows, or
 support research software and data engineering.
 
+::: callout-note
+Since we aim to build beginner-friendly tools, we put a strong emphasis
+on documentation.
+Our software and software-related products include technical documentation in the form of design documentation, usage guides, and reference documentation when
+relevant.
+:::
+
 ::: panel-tabset
 #### Software
 


### PR DESCRIPTION
# Description

Because the same repositories are listed multiple times, the roadmap becomes more difficult to maintain, for example having to update the descriptions multiple times. Instead, I've added a callout about our software and software-related products including documentation. 

This PR needs a an in-depth review.

## Checklist

- [ ] Formatted Markdown
- [X] Ran `just run-all`
