### PR TITLE
refactor: 📝 update `README` content and match landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     </a>
 </p>
 
-# seedcase-project: Grow FAIR and tidy data
+# seedcase-project: Growing FAIR and tidy data
 
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-teal.json?raw=true.svg)](https://github.com/copier-org/copier)
 [![GitHub
@@ -22,19 +22,27 @@ status](https://results.pre-commit.ci/badge/github/seedcase-project/seedcase-web
 state and is being actively
 developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
-In many fields of science, managing and structuring data in FAIR
-(Findable, Accessible, Interoperable, Reusable) ways can be a major
-barrier to fully utilising the data collected from a study. This is
-largely a software and training issue, complicated by the fact that
-funding is often restricted for this type of work as it is often
-undervalued.
+## What we do
 
-In the Seedcase Project, we aim to build software tools that make it
-easier to manage and work with data. This repository contains the files
-used for our main website,
-[seedcase-project.org](https://seedcase-project.org). Check it out for
-more information about the project, our values, and the software we are
-building.
+Our vision is to make it as easy as possible to create, build, and use
+FAIR (Findable, Accessible, Interoperable, and Reusable), tidy, and
+high-quality data, ultimately reducing the time from data generation to
+scientific dissemination.
+
+Our strategy to work towards this vision is to:
+
+- Collaborate with research groups to engineer and build FAIR and tidy
+  data packages
+- Develop open-source tools that automate and streamline building these
+  data packages.
+- Upskill and empower researchers and data owners through mentoring,
+  training, guides, and tutorials.
+
+Check our [website](https://seedcase-project.org/) for more details,
+such as our roadmap, products, team, links to our other websites, and
+our collaborators.
+
+## Funding and affiliations
 
 This project is funded by a grant from the Novo Nordisk Foundation. See
 our grant proposal here: [![Grant proposal
@@ -59,16 +67,6 @@ By contributing to this project, you agree to abide by its terms.
 > This website repository was generated from the
 > [`template-website`](https://github.com/seedcase-project/template-website)
 > Seedcase template :tada:
-
-## Contributing
-
-Check out our [contributing document](CONTRIBUTING.md) for information
-on how to contribute to the project, including how to set up your
-development environment.
-
-Please note that this project is released with a [Contributor Code of
-Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree
-to abide by its terms.
 
 ### Contributors
 

--- a/README.qmd
+++ b/README.qmd
@@ -16,17 +16,24 @@ metadata-files:
 
 {{< include /includes/_badges.qmd >}}
 
-In many fields of science, managing and structuring data in FAIR (Findable,
-Accessible, Interoperable, Reusable) ways can be a major barrier to fully
-utilising the data collected from a study. This is largely a software and
-training issue, complicated by the fact that funding is often restricted for
-this type of work as it is often undervalued.
+## What we do
 
-In the Seedcase Project, we aim to build software tools that make it easier to
-manage and work with data. This repository contains the files used for our main
-website, [seedcase-project.org](https://seedcase-project.org). Check it out for
-more information about the project, our values, and the software we are
-building.
+Our vision is to make it as easy as possible to create, build, and use FAIR
+(Findable, Accessible, Interoperable, and Reusable), tidy, and high-quality
+data, ultimately reducing the time from data generation to scientific
+dissemination.
+
+Our strategy to work towards this vision is to:
+
+- Collaborate with research groups to engineer and build FAIR and tidy data
+  packages
+- Develop open-source tools that automate and streamline building these data
+  packages.
+- Upskill and empower researchers and data owners through mentoring, training,
+  guides, and tutorials.
+
+Check our [website](https://seedcase-project.org/) for more details, such as our
+roadmap, products, team, links to our other websites, and our collaborators.
 
 This project is funded by a grant from the Novo Nordisk Foundation. See our
 grant proposal here: [![Grant proposal

--- a/README.qmd
+++ b/README.qmd
@@ -35,6 +35,8 @@ Our strategy to work towards this vision is to:
 Check our [website](https://seedcase-project.org/) for more details, such as our
 roadmap, products, team, links to our other websites, and our collaborators.
 
+## Funding and affiliations
+
 This project is funded by a grant from the Novo Nordisk Foundation. See our
 grant proposal here: [![Grant proposal
 DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6511112.svg)](https://doi.org/10.5281/zenodo.6511112).

--- a/README.qmd
+++ b/README.qmd
@@ -60,15 +60,6 @@ This website repository was generated from the
 Seedcase template :tada:
 :::
 
-## Contributing
-
-Check out our [contributing document](CONTRIBUTING.md) for information on how to
-contribute to the project, including how to set up your development environment.
-
-Please note that this project is released with a [Contributor Code of
-Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to
-abide by its terms.
-
 ### Contributors
 
 {{< include /includes/_contributors.qmd >}}

--- a/_metadata.yml
+++ b/_metadata.yml
@@ -2,7 +2,7 @@ gh:
   org: seedcase-project
   repo: seedcase-website
 
-tagline: "Grow FAIR and tidy data"
+tagline: "Growing FAIR and tidy data"
 
 links:
   github: "https://github.com/seedcase-project/seedcase-website"

--- a/includes/_contributors.qmd
+++ b/includes/_contributors.qmd
@@ -5,5 +5,4 @@ requests :tada:
 [\@lwjohnst86](https://github.com/lwjohnst86),
 [\@martonvago](https://github.com/martonvago),
 [\@namannimmo10](https://github.com/namannimmo10),
-[\@rqding](https://github.com/rqding),
-[\@signekb](https://github.com/signekb)
+[\@rqding](https://github.com/rqding), [\@signekb](https://github.com/signekb)

--- a/includes/_contributors.qmd
+++ b/includes/_contributors.qmd
@@ -5,4 +5,5 @@ requests :tada:
 [\@lwjohnst86](https://github.com/lwjohnst86),
 [\@martonvago](https://github.com/martonvago),
 [\@namannimmo10](https://github.com/namannimmo10),
-[\@rqding](https://github.com/rqding), [\@signekb](https://github.com/signekb)
+[\@rqding](https://github.com/rqding),
+[\@signekb](https://github.com/signekb)


### PR DESCRIPTION
# Description

This matches the `README` to match the landing page (and org `README`) as well as cleans it up a bit (e.g., removing the duplicate "Contributing" section.

Needs a quick review.

## Checklist

- [X] Ran `just run-all` (this does mangle the `_badges.qmd` and thereby also the `README.md`, but I haven't included that here ofc) 
